### PR TITLE
Polygon sampling

### DIFF
--- a/pinnicle/modeldata/general_mat_data.py
+++ b/pinnicle/modeldata/general_mat_data.py
@@ -61,6 +61,15 @@ class MatData(DataBase, Constants):
         for k in self.parameters.name_map:
             self.data_dict[k] = (data[self.parameters.name_map[k]][boxflag].flatten()[:,None])*self.parameters.scaling[k]
 
+        if self.parameters.sample_only_inside:
+            P = np.hstack((self.X_dict[xkeys[0]],self.X_dict[xkeys[1]]))
+            inside = domain.inside(P)
+            mask = np.where(inside!=0)
+            for k in X.keys():
+                self.X_dict[k] = self.X_dict[k][mask]
+            for k,v in self.parameters.name_map.items():
+                self.data_dict[k] = self.data_dict[k][mask]
+
     def plot(self, data_names=[], vranges={}, axs=None, **kwargs):
         """ TODO: scatter plot of the selected data from data_names
         """

--- a/pinnicle/modeldata/h5_data.py
+++ b/pinnicle/modeldata/h5_data.py
@@ -60,6 +60,15 @@ class H5Data(DataBase, Constants):
         for k in self.parameters.name_map:
             self.data_dict[k] = data[self.parameters.name_map[k]][boxflag].flatten()[:,None]
 
+        if self.parameters.sample_only_inside:
+            P = np.hstack((self.X_dict[xkeys[0]],self.X_dict[xkeys[1]]))
+            inside = domain.inside(P)
+            mask = np.where(inside!=0)
+            for k in X.keys():
+                self.X_dict[k] = self.X_dict[k][mask]
+            for k,v in self.parameters.name_map.items():
+                self.data_dict[k] = self.data_dict[k][mask]
+
     def plot(self, data_names=[], vranges={}, axs=None, **kwargs):
         """ TODO: scatter plot of the selected data from data_names
         """

--- a/pinnicle/modeldata/netcdf_data.py
+++ b/pinnicle/modeldata/netcdf_data.py
@@ -83,6 +83,16 @@ class NetCDFData(DataBase, Constants):
         self.X_dict[xkeys[0]] = X_mesh.flatten()[:,None]
         self.X_dict[xkeys[1]] = Y_mesh.flatten()[:,None]
 
+        if self.parameters.sample_only_inside:
+            P = np.hstack((self.X_dict[xkeys[0]],self.X_dict[xkeys[1]]))
+            inside = domain.inside(P)
+            mask = np.where(inside!=0)
+            self.X_dict[xkeys[0]] = self.X_dict[xkeys[0]][mask]
+            self.X_dict[xkeys[1]] = self.X_dict[xkeys[1]][mask]
+            for k,v in self.parameters.name_map.items():
+                self.data_dict[k] = self.data_dict[k][mask]
+
+
     def plot(self, data_names=[], vranges={}, axs=None, **kwargs):
         """ TODO: scatter plot of the selected data from data_names
         """

--- a/pinnicle/parameter.py
+++ b/pinnicle/parameter.py
@@ -156,6 +156,8 @@ class SingleDataParameter(ParameterBase):
         self.name_map = {}
         # X name map k->v, k is the input names in the PINN, v is the coordinates name in the data file
         self.X_map = {}
+        # sample data points only inside the polygon domain, rather than the bbox
+        self.sample_only_inside = False
         # scaling factor, map using k->s, by default s=1, k is the same (or subset) as in data_size
         self.scaling = {}
         # source of the data

--- a/pinnicle/utils/helper.py
+++ b/pinnicle/utils/helper.py
@@ -24,11 +24,8 @@ def save_dict_to_json(data, path, filename):
     """
     if not filename.endswith('.json'):
         filename += '.json'
-    data2 = {}
-    for k,v in data.items():
-        data2[k] = [round(float(x),8) for x in v]
     with open(os.path.join(path,filename), "w") as fp:
-        json.dump(data2, fp)
+        json.dump(data, fp)
 
 def load_dict_from_json(path, filename):
     """ Load a dict data from a .json file 

--- a/pinnicle/utils/helper.py
+++ b/pinnicle/utils/helper.py
@@ -24,8 +24,11 @@ def save_dict_to_json(data, path, filename):
     """
     if not filename.endswith('.json'):
         filename += '.json'
+    data2 = {}
+    for k,v in data.items():
+        data2[k] = [round(float(x),8) for x in v]
     with open(os.path.join(path,filename), "w") as fp:
-        json.dump(data, fp)
+        json.dump(data2, fp)
 
 def load_dict_from_json(path, filename):
     """ Load a dict data from a .json file 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -246,6 +246,29 @@ def test_MatData_domain():
     icoord = data_loader.get_ice_coordinates()
     assert icoord.shape == (673,2)
 
+def test_MatData_domain_polygon_sampling():
+    filename = "flightTracks.mat"
+    expFileName = "fastflow_CF.exp"
+    repoPath = os.path.dirname(__file__) + "/../examples/"
+    appDataPath = os.path.join(repoPath, "dataset")
+    path = os.path.join(appDataPath, filename)
+    
+    hp = {}
+    hp["data_path"] = path
+    hp["data_size"] = {"H":"Max"}
+    hp["name_map"] = {"H":"thickness"}
+    hp["source"] = "mat"
+    hp["X_map"] = {"x1":"x", "x2":"y"}
+    hp["shapefile"] = os.path.join(repoPath, "dataset", expFileName)
+    hp["sample_only_inside"] = True
+
+    d = pinn.domain.Domain( pinn.parameter.DomainParameter(hp))
+    p = SingleDataParameter(hp)
+    data_loader = MatData(p)
+    data_loader.load_data(d)
+    icoord = data_loader.get_ice_coordinates()
+    assert icoord.shape == (502,2)
+
 def test_MatData_physics():
     filename = "flightTracks.mat"
     expFileName = "fastflow_CF.exp"
@@ -319,6 +342,29 @@ def test_h5Data_domain():
     assert(data_loader.sol['a'].shape == (10,1))
     icoord = data_loader.get_ice_coordinates()
     assert icoord.shape == (51800,2)
+
+def test_h5Data_domain_polygon_sampling():
+    filename = "subdomain_data.h5"
+    expFileName = "fastflow_CF.exp"
+    repoPath = os.path.dirname(__file__) + "/../examples/"
+    appDataPath = os.path.join(repoPath, "dataset")
+    path = os.path.join(appDataPath, filename)
+
+    hp = {}
+    hp["data_path"] = path
+    hp["data_size"] = {"u":300, "v":100, "s":2, "b":100, "a":10}
+    hp["X_map"] = {"x":"surf_x", "y":"surf_y" }
+    hp["name_map"] = {"s":"surf_elv", "u":"surf_vx", "v":"surf_vy", "a":"surf_SMB", "b":"bed_BedMachine"}
+    hp["source"] = "h5"
+    hp["shapefile"] = os.path.join(repoPath, "dataset", expFileName)
+    hp["sample_only_inside"] = True
+
+    d = pinn.domain.Domain( pinn.parameter.DomainParameter(hp))
+    p = SingleDataParameter(hp)
+    data_loader = H5Data(p)
+    data_loader.load_data(d)
+    icoord = data_loader.get_ice_coordinates()
+    assert icoord.shape == (38771,2)
 
 def test_h5Data_physics():
     filename = "subdomain_data.h5"
@@ -405,6 +451,29 @@ def test_ncData_domain():
 
     with pytest.raises(Exception):
         data_loader.load_data(d)
+
+def test_ncData_domain_polygon_sampling():
+    filename = "subdomain_bed.nc"
+    expFileName = "fastflow_CF.exp"
+    repoPath = os.path.dirname(__file__) + "/../examples/"
+    appDataPath = os.path.join(repoPath, "dataset")
+    path = os.path.join(appDataPath, filename)
+    
+    hp = {}
+    hp["data_path"] = path
+    hp["data_size"] = {"s":300, "H":"MAX", "b":10}
+    hp["X_map"] = {"x":"x", "y":"y" }
+    hp["name_map"] = {"s":"surface", "H":"thickness", "b":"bed"}
+    hp["source"] = "nc"
+    hp["shapefile"] = os.path.join(repoPath, "dataset", expFileName)
+    hp["sample_only_inside"] = True
+
+    d = pinn.domain.Domain( pinn.parameter.DomainParameter(hp))
+    p = SingleDataParameter(hp)
+    data_loader = NetCDFData(p)
+    data_loader.load_data(d)
+    icoord = data_loader.get_ice_coordinates()
+    assert icoord.shape == (9381, 2)
 
 def test_ncData_physics():
     filename = "subdomain_bed.nc"


### PR DESCRIPTION
add a hp flag to mask out data outside the polygon domain when loading uncropped data files

in setup script, specify:
hp['sample_only_inside'] = True
with default being False

implemented with tests for mat, nc, and h5 data

also, fix a numpy bug in save_dict_to_json in utils/helper.py