### PR TITLE
bug fix, generate random seed and save automatically

### DIFF
--- a/pinnicle/parameter.py
+++ b/pinnicle/parameter.py
@@ -411,6 +411,8 @@ class TrainingParameter(ParameterBase):
 
 
     def set_default(self):
+        # random seed, set default to None
+        self.random_seed = None
         # number of epochs
         self.epochs = 0
         # optimization method

--- a/pinnicle/pinn.py
+++ b/pinnicle/pinn.py
@@ -2,6 +2,7 @@ import os
 import glob
 import deepxde as dde
 import numpy as np
+import warnings
 
 from .utils import save_dict_to_json, load_dict_from_json, History, plot_solutions, data_misfit
 from .nn import FNN
@@ -26,7 +27,22 @@ class PINN:
         self.params = Parameters(params)
 
         # set up the model according to self.params
-        self.setup()
+        self.setup() 
+        
+        # if random seed not defined, randomly choose
+        if self.params.training.random_seed is None:
+            warnings.warn('Random seed is undefined by user (None). Generating random seed...')
+            rand_seed = np.random.randint(1, 9999)
+            self.update_parameters({"random_seed":rand_seed})
+        # edge cases
+        if type(self.params.training.random_seed) is not int:
+            raise TypeError("Random seed must be an integer")
+        if (self.params.training.random_seed < 1) or (self.params.training.random_seed > 9999):
+            raise ValueError("Random seed not supported, must be between 1 and 9999")
+ 
+        # initialize random seed
+        print('Configuring random seed: '+str(self.params.training.random_seed))
+        dde.config.set_random_seed(self.params.training.random_seed)
 
     def check_path(self, path, loadOnly=False):
         """check the path, set to default, and create folder if needed
@@ -41,7 +57,7 @@ class PINN:
     def compile(self, opt=None, loss=None, lr=None, loss_weights=None, decay=None):
         """ compile the model  
         """
-        # load from params
+
         if opt is None:
             opt = self.params.training.optimizer
 

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -193,6 +193,7 @@ def test_training_parameters():
     assert p.decay_steps == 10
     assert p.decay_rate == 0.3
     assert p.additional_loss == {}
+
     u_loss = {}
     u_loss['name'] = "vel log"
     u_loss['function'] = "VEL_LOG"
@@ -200,6 +201,10 @@ def test_training_parameters():
     hp['additional_loss'] = {"u": u_loss}
     p = TrainingParameter(hp)
     assert p.additional_loss["u"].name == u_loss['name']
+
+    hp['random_seed'] = 1234
+    p = TrainingParameter(hp)
+    assert p.random_seed == 1234
 
 def test_training_callbacks():
     hp = {}

--- a/tests/test_pinn.py
+++ b/tests/test_pinn.py
@@ -5,6 +5,7 @@ import deepxde as dde
 from deepxde.backend import backend_name
 from pinnicle.utils import data_misfit, plot_nn
 import pytest
+import warnings
 
 dde.config.set_default_float('float64')
 #dde.config.disable_xla_jit()
@@ -64,6 +65,7 @@ def test_compile_no_data():
     hp_local = dict(hp)
     issm["data_size"] = {}
     hp_local["data"] = {"ISSM":issm}
+    hp_local["random_seed"] = 1234
     experiment = pinn.PINN(params=hp_local)
     experiment.compile()
     assert experiment.loss_names == ['fSSA1', 'fSSA2']
@@ -72,6 +74,25 @@ def test_compile_no_data():
     assert experiment.params.nn.output_ub[0]>0.0
     assert experiment.params.nn.output_lb[1]<0.0
     assert experiment.params.nn.output_ub[1]>0.0
+
+def test_random_seed():
+    with pytest.warns(UserWarning):
+        experiment = pinn.PINN(params=hp)
+        warnings.warn("Random seed is undefined by user (None). Generating random seed...", UserWarning)
+    with pytest.raises(TypeError):
+        hp["random_seed"] = '1234'
+        experiment = pinn.PINN(params=hp)
+    with pytest.raises(ValueError):
+        hp["random_seed"] = -1
+        experiment = pinn.PINN(params=hp)
+    with pytest.raises(ValueError):
+        hp["random_seed"] = 10000
+        experiment = pinn.PINN(params=hp)
+    hp["random_seed"] = 1234
+    experiment = pinn.PINN(params=hp)
+    experiment.compile()
+    assert type(experiment.params.training.random_seed) == int
+    assert experiment.params.training.random_seed == 1234
 
 def test_add_loss():
     hp_local = dict(hp)


### PR DESCRIPTION
Configure PINN with random seed, if not provided by user. When re-loading also initialising with the same random seed. 